### PR TITLE
add component-lifecyle content

### DIFF
--- a/content/component-lifecycle.mdx
+++ b/content/component-lifecycle.mdx
@@ -2,5 +2,52 @@
 title: Component lifecycle
 ---
 
-_TODO_
+These milestones summarize the maturity lifecycle of UI components in Primer. Components must meet all criteria _before_ proceeding to a given milestone.
 
+## Experimental
+
+Proof-of-concept built outside of Primer.
+
+- The component exists as a proof-of-concept built outside of Primer, often in a GitHub application such as GitHub.com.
+
+## Alpha
+
+The component is ready for preliminary usage, with breaking changes expected.
+
+- <details><summary>The component does not have external dependencies. </summary>This could be external libraries or dependencies on libraries in an application (like GitHub.com)</details>
+- <details><summary>The component is compatible with color modes and can adapt to different themes. </summary>The component does not reference any hard-coded static values and uses functional variables. Any temporary or app-level variables have been removed. Theme values (such as a new brand scheme) can be swapped out without touching the public API of the component.</details>
+- Basic documentation exists that includes example usage of the component.
+- Primary use cases tested and reviewed.
+- The component has 100% test coverage.
+
+## Beta
+
+The component meets most maturity criteria, and use is encouraged for most scenarios.
+
+- <details><summary>The component is used in a production application in multiple instances.</summary>Expectation is three or more instances in dotcom for Primer ViewComponents, at least one or more instances for Primer React. Uses of the component have been reviewed for correctness.</details>
+- <details><summary>Usage guidelines and configuration documentation covers common use cases.</summary>Implementation of additional features (secondary priorities) is expected during beta. Additional and most common use cases should be documented by this phase. Documentation should include a sandbox environment such as Storybook.</details>
+- <details><summary>The design has been reviewed and any resulting issues have been addressed.</summary>Systems Designers have reviewed the current implementation and how it’s used in production.</details>
+- The accessibility team has manually reviewed the component and any outstanding issues have been fixed.
+- <details><summary>The component does not introduce unnecessary performance regressions to the user experience or the Primer library.
+
+## Stable
+
+The component is significantly mature and usage is strongly encouraged, with long-term support expected.
+
+- <details><summary>The API remains stable, with no breaking changes for at least one month.</summary>Feedback on API usabliity has been sought from developers using the component and production use cases have been reviewed for correctness.</details>
+- <details><summary>Documentation exists for the remaining implementation, usage, and design guidelines.</summary>Primer React and/or Primer ViewComponents documentation includes all props and variations, accessibility guidelines (including common misuses), and common scenarios. Design documentation is added to Interface Guidelines. Figma components are available in the Primer Web library.</details>
+- Tooling (such as linters, codemods, etc.) exists to prevent further use of alternatives.
+
+## Deprecated
+
+The component will be removed in the future and should be avoided.
+
+- Documentation exists for the deprecation, including any alternative components to use instead.
+- When using the component, a warning is shown to the consumer.
+
+## Removed
+
+The component no longer exists in Primer.
+
+- The removal date has been announced and is at least one month away from the release date of the package that removes the component..
+- Manual and automated migration paths are documented and have been available for at least one month.

--- a/content/component-lifecycle.mdx
+++ b/content/component-lifecycle.mdx
@@ -14,8 +14,8 @@ Proof-of-concept built outside of Primer.
 
 The component is ready for preliminary usage, with breaking changes expected.
 
-- <details><summary>The component does not have external dependencies. </summary>This could be external libraries or dependencies on libraries in an application (like GitHub.com)</details>
-- <details><summary>The component is compatible with color modes and can adapt to different themes. </summary>The component does not reference any hard-coded static values and uses functional variables. Any temporary or app-level variables have been removed. Theme values (such as a new brand scheme) can be swapped out without touching the public API of the component.</details>
+- The component does not have external dependencies. This could be external libraries or dependencies on libraries in an application (like GitHub.com)
+- The component is compatible with color modes and can adapt to different themes. The component does not reference any hard-coded static values and uses functional variables. Any temporary or app-level variables have been removed. Theme values (such as a new brand scheme) can be swapped out without touching the public API of the component.
 - Basic documentation exists that includes example usage of the component.
 - Primary use cases tested and reviewed.
 - The component has 100% test coverage.
@@ -24,18 +24,18 @@ The component is ready for preliminary usage, with breaking changes expected.
 
 The component meets most maturity criteria, and use is encouraged for most scenarios.
 
-- <details><summary>The component is used in a production application in multiple instances.</summary>Expectation is three or more instances in dotcom for Primer ViewComponents, at least one or more instances for Primer React. Uses of the component have been reviewed for correctness.</details>
-- <details><summary>Usage guidelines and configuration documentation covers common use cases.</summary>Implementation of additional features (secondary priorities) is expected during beta. Additional and most common use cases should be documented by this phase. Documentation should include a sandbox environment such as Storybook.</details>
-- <details><summary>The design has been reviewed and any resulting issues have been addressed.</summary>Systems Designers have reviewed the current implementation and how it’s used in production.</details>
+- The component is used in a production application in multiple instances. Expectation is three or more instances in dotcom for Primer ViewComponents, at least one or more instances for Primer React. Uses of the component have been reviewed for correctness.
+- Usage guidelines and configuration documentation covers common use cases. Implementation of additional features (secondary priorities) is expected during beta. Additional and most common use cases should be documented by this phase. Documentation should include a sandbox environment such as Storybook.
+- The design has been reviewed and any resulting issues have been addressed. Systems Designers have reviewed the current implementation and how it’s used in production.
 - The accessibility team has manually reviewed the component and any outstanding issues have been fixed.
-- <details><summary>The component does not introduce unnecessary performance regressions to the user experience or the Primer library.
+- The component does not introduce unnecessary performance regressions to the user experience or the Primer library.
 
 ## Stable
 
 The component is significantly mature and usage is strongly encouraged, with long-term support expected.
 
-- <details><summary>The API remains stable, with no breaking changes for at least one month.</summary>Feedback on API usabliity has been sought from developers using the component and production use cases have been reviewed for correctness.</details>
-- <details><summary>Documentation exists for the remaining implementation, usage, and design guidelines.</summary>Primer React and/or Primer ViewComponents documentation includes all props and variations, accessibility guidelines (including common misuses), and common scenarios. Design documentation is added to Interface Guidelines. Figma components are available in the Primer Web library.</details>
+- The API remains stable, with no breaking changes for at least one month. Feedback on API usability has been sought from developers using the component and production use cases have been reviewed for correctness.
+- Documentation exists for the remaining implementation, usage, and design guidelines. Primer React and/or Primer ViewComponents documentation includes all props and variations, accessibility guidelines (including common misuses), and common scenarios. Design documentation is added to Interface Guidelines. Figma components are available in the Primer Web library.
 - Tooling (such as linters, codemods, etc.) exists to prevent further use of alternatives.
 
 ## Deprecated


### PR DESCRIPTION
This PR introduces a `Lifecycle` page to the design guidelines on `primer.style`.

## Context

As part of our goals we're working on increasing the maturity of Primer, to make it more robust and consistent, and to create clarity for people working with the system. Our component libraries have diverged as we experimented and developed different parts of Primer, and we don't have all the pattern coverage we think consumers need across the system. These criteria are meant to establish baseline expectations for components in Primer as they mature over time.

## Notes

We had originally titled these levels `maturity statuses` but I feel that the term `Lifecycle` better captures the intention for this to be a process that we move components through.  I also used the term `milestone` in place of `status` for similar reasons.
