### PR TITLE
Updating Primer project board link

### DIFF
--- a/content/how-to-contribute.md
+++ b/content/how-to-contribute.md
@@ -42,7 +42,7 @@ You can contribute to new patterns either by design, prototype and build proofs 
 
 Please read the [guidelines on designing Primer patterns](https://primer.style/contribute/design).
 
-From the [Primer project board](https://github.com/github/primer/projects/1) (GitHub staff only), you can grab anything from **Unprioritized backlog** and **Up next** — just reach out to us first in Slack or the issue itself.
+From the [Primer project board](https://github.com/orgs/github/projects/2759) (GitHub staff only), you can grab anything from **Unprioritized backlog** and **Up next** — just reach out to us first in Slack or the issue itself.
 
 ## Give us feedback and report bugs 
 


### PR DESCRIPTION
This PR updates a link in the "how to contribute" documentation to point to the [currently active](https://github.com/orgs/github/projects/2759) Primer project board (for GitHub staff only) instead of the [deprecated one](https://github.com/github/primer/projects/1).

You can test by:
1. Visit the deploy preview https://primer-contribute-git-lcw-updating-primer-proje-afa607-monalisa.vercel.app/contribute/how-to-contribute#design-or-build-new-patterns
2. Click on the link to the "Primer backlog"
3. Confirm the project board is active and not deprecated