### PR TITLE
Updating criteria for "experimental" lifecycle to indicate these may be built within Primer

### DIFF
--- a/content/component-lifecycle.md
+++ b/content/component-lifecycle.md
@@ -6,9 +6,9 @@ These milestones summarize the maturity lifecycle of UI components in Primer. Co
 
 ## Experimental
 
-Proof-of-concept built outside of Primer.
+Proof-of-concept, often built outside of Primer.
 
-- The component exists as a proof-of-concept built outside of Primer, often in a GitHub application such as GitHub.com.
+- The component exists as a proof-of-concept. In many cases experimental components may be built outside of Primer, often in a GitHub application such as GitHub.com.
 
 ## Alpha
 


### PR DESCRIPTION
We have recently been building "experimental" components inside Primer much more often. In particular, this is true within Primer Brand, where we are aiming to create a usable initial slate of components.

To avoid confusion, this slight change to the lifecycle criteria docs calls out that experimental components may or may not be built within Primer.