### PR TITLE
Move a11y criteria from Beta to Alpha stage

### DIFF
--- a/content/component-lifecycle.md
+++ b/content/component-lifecycle.md
@@ -23,6 +23,7 @@ The component is ready for preliminary usage, with breaking changes expected.
 - The component has visual regression coverage of its default and interactive states.
 - The component has robust test coverage for its interactive (stateful) behaviour, which has been verified in end-to-end and/or open-box testing suites.
 - The component does not introduce any [axe](https://www.deque.com/axe/) violations.
+- The component has been manually reviewed for accessibility and any outstanding issues have been fixed.
 
 ## Beta
 
@@ -31,7 +32,6 @@ The component meets most maturity criteria, and use is encouraged for most scena
 - The component is used in a production application in multiple instances. Expectation is three or more instances in dotcom for Primer ViewComponents, at least one or more instances for Primer React. Uses of the component have been reviewed for correctness.
 - Usage guidelines and configuration documentation covers common use cases. Implementation of additional features (secondary priorities) is expected during beta. Additional and most common use cases should be documented by this phase. Documentation should include a sandbox environment such as Storybook.
 - The design has been reviewed and any resulting issues have been addressed. Systems Designers have reviewed the current implementation, validated its responsive strategy, and how it’s used in production.
-- The accessibility team has manually reviewed the component and any outstanding issues have been fixed.
 - The component does not introduce unnecessary performance regressions to the user experience or the Primer library.
 
 ## Stable


### PR DESCRIPTION
We previously agreed that accessibility reviews should be completed at the "alpha" stage of the component lifecycle. We made this change to shift accessibility further left in our process and reduce the amount of rework needed on more mature components in order to satisfy accessibility requirements.

I believe this change was previously communicated to Primer maintainers and that we are already following this standard on recent component work.

fyi @broccolinisoup who brought this to my attention 🙏🏻 